### PR TITLE
Бафф регена некоторым лазерам.

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -45,7 +45,7 @@ obj/item/weapon/gun/energy/laser/retro
 	if(charge_tick < 4) return 0
 	charge_tick = 0
 	if(!power_supply) return 0
-	power_supply.give(100)
+	power_supply.give(1000)
 	update_icon()
 	return 1
 
@@ -109,7 +109,7 @@ obj/item/weapon/gun/energy/laser/retro
 	charge_tick = 0
 	if(!power_supply)
 		return 0
-	power_supply.give(100)
+	power_supply.give(1000)
 	update_icon()
 	return 1
 
@@ -140,6 +140,6 @@ obj/item/weapon/gun/energy/laser/retro
 	charge_tick = 0
 	if(!power_supply)
 		return 0
-	power_supply.give(100)
+	power_supply.give(1000)
 	update_icon()
 	return 1

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -53,7 +53,7 @@
 	if(charge_tick < 4) return 0
 	charge_tick = 0
 	if(!power_supply) return 0
-	if((power_supply.charge / power_supply.maxcharge) != 1)
+	if((power_supply.charge / power_supply.maxcharge) < 1)
 		if(!failcheck())	return 0
 		power_supply.give(1000)
 		update_icon()


### PR DESCRIPTION
#93
Чтобы соответствовали повышенным энергозатратам (всем пушкам ранее была поставлена в 10 раз более емкая батарея, которых на станции как мусора, чтобы всякие набегаторы не могли легким движением руки делать себе лазер на 100 зарядов, ну и затраты на выстрел были повышены тоже в 10 раз; про реген кэплазора и ретролазеров тогда не вспомнили, сейчас поправил). Ну и поменял проверку зарядки для нюклазора на идейно верную.