### PR TITLE
Понизил энергозатраты на тазеринг еганом ХоСа.

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -65,7 +65,7 @@
 	e_cost = 1000
 
 /obj/item/ammo_casing/energy/electrode/hos
-	e_cost = 2000
+	e_cost = 1250
 
 /obj/item/ammo_casing/energy/ion
 	projectile_type = /obj/item/projectile/ion


### PR DESCRIPTION
Ибо он по остальным снарядам был идентичен еганам-тазерам, а на тазеры жрал в два раза больше. Затраты на выстрел в режиме тазера сменены с 2к на 1.25к, что дает 8 выстрелов на стандартный (10к заряд) аккумулятор (было 5) против 10 выстрелов у тазера и егана, что все еще соответствует тому, что еган хоса более универсальный, но проигрывающий тазеру и егану по эффективности, но в то же время делает его не столь ущербным.