### PR TITLE
Плавное слежение для гостов.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,6 +24,10 @@
 	///Chemistry.
 	var/allow_spin = 1
 
+	//attempt to make better follow for ghosts and AI
+	///movables will move all followers to itself in proc/Moved
+	var/list/followers = list()
+
 /atom/proc/onCentcom()
 	var/turf/T = get_turf(src)
 	if(!T)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,10 +24,6 @@
 	///Chemistry.
 	var/allow_spin = 1
 
-	//attempt to make better follow for ghosts
-	///movables will move all followers to itself in proc/Moved
-	var/list/followers = list()
-
 /atom/proc/onCentcom()
 	var/turf/T = get_turf(src)
 	if(!T)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,7 +24,7 @@
 	///Chemistry.
 	var/allow_spin = 1
 
-	//attempt to make better follow for ghosts and AI
+	//attempt to make better follow for ghosts
 	///movables will move all followers to itself in proc/Moved
 	var/list/followers = list()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -65,7 +65,14 @@
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
+	HandleFollowers() //for some wicked reason some of movables (ghosts) actually doesn't call Moved after Move, so for these we put that behaviour in separate proc
 	return 1
+
+/atom/movable/proc/HandleFollowers()
+	for(var/atom/movable/M in followers)
+		if(M==src) //O_o sanity check
+			continue
+		M.Move(get_turf(src))
 
 /atom/movable/Del()
 	if(isnull(gc_destroyed) && loc)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -70,7 +70,8 @@
 
 /atom/movable/proc/HandleFollowers()
 	for(var/atom/movable/M in followers)
-		if(M==src) //O_o sanity check
+		if(!M || M==src) //O_o sanity check
+			followers.Remove(M)
 			continue
 		M.Move(get_turf(src))
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -18,7 +18,6 @@ var/list/image/ghost_darkness_images = list() //this is a list of images for thi
 							//If you died in the game and are a ghsot - this will remain as null.
 							//Note that this is not a reliable way to determine if admins started as observers, since they change mobs a lot.
 	var/medHUD = 0
-	var/atom/movable/following = null
 	var/fun_verbs = 0
 	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
@@ -130,7 +129,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/Move(NewLoc, direct)
 	if(NewLoc)
 		if(following && NewLoc!=get_turf(following))
-			ManualUnFollow()
+			UnFollow()
 		loc = NewLoc
 		for(var/obj/effect/step_trigger/S in NewLoc)
 			S.Crossed(src)
@@ -252,12 +251,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		target.followers |= src //make it know we follow it
 		Move(get_turf(target)) //initial jump
 
-/mob/dead/observer/proc/ManualUnFollow()
-	if(!following)
-		return
-	following.followers.Remove(src)
-	src << "<span class='notice'>Stopped following [following].</span>"
-	following = null
+/mob/dead/observer/UnFollow()
+	if(..())
+		src << "<span class='notice'>Stopped following [following].</span>"
 
 /mob/dead/observer/verb/jumptomob() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"


### PR DESCRIPTION
Запилил поддержку следования мувейбла за мувейблом, подпилил к ней гостов. Посмотрел на код трекинга ИИ, решил его не трогать, благо оный трекинг и так весьма плавный.
Последний коммит добавляет защиту от бесконечных рекурсий в случае цепочек следования (один следует за другим, тот за следующим, и в какой-то момент очередной следователь следует за самым первым упомянутым). Вроде все нормально работает.
Пока без графония, как у ТГшников (т.е. без кручения гостов вокруг объекта следования), но тем не менее плавно.
Работает по принципу "переместился - перемести следующих за тобой (заодно проверь, нету ли ебучих циклов, и в случае цикла перестань следовать сам)".